### PR TITLE
Add option to skip downloading cluster data if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 
 .PHONY: setup
 setup:
-	@(printf "Project is: "; read PROJECT; printf "Shoot is: "; read SHOOT; ./bin/dev setup -project $$PROJECT -shoot $$SHOOT);
+	@(printf "Project is: "; read PROJECT; printf "Shoot is: "; read SHOOT; ./bin/dev setup -project $$PROJECT -shoot $$SHOOT -skip-download true);
 
 .PHONY: start
 start:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Usage of setup:
     	Gardener Shoot Name - fallback to env SHOOT
   -skip-build
     	Skips building binaries if already present
+  -skip-download
+        Skips downloading cluster data if already present
 ```
 
 


### PR DESCRIPTION
If cluster data is present and the option `skip-download` is specified during setup, avoid downloading the cluster data.